### PR TITLE
Aktivere HTMLGen i apiet (tilknyttet vedtaksbrev EY-973)

### DIFF
--- a/apps/ey-pdfgen/.nais/dev.yaml
+++ b/apps/ey-pdfgen/.nais/dev.yaml
@@ -17,6 +17,9 @@ spec:
   prometheus:
     enabled: true
     path: /prometheus
+  env:
+    - name: ENABLE_HTML_ENDPOINT
+      value: "true"
   accessPolicy:
     inbound:
       rules:

--- a/apps/ey-pdfgen/.nais/prod.yaml
+++ b/apps/ey-pdfgen/.nais/prod.yaml
@@ -17,6 +17,9 @@ spec:
   prometheus:
     enabled: true
     path: /prometheus
+  env:
+    - name: ENABLE_HTML_ENDPOINT
+      value: "true"
   accessPolicy:
     inbound:
       rules:

--- a/apps/ey-pdfgen/Dockerfile
+++ b/apps/ey-pdfgen/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/pdfgen:1.5.0
+FROM ghcr.io/navikt/pdfgen:1.5.3
 
 COPY templates /app/templates
 COPY fonts /app/fonts


### PR DESCRIPTION
Bumpe til v1.5.3 og aktivere HTML-endepunkt. Gjør det mulig å generere brev-html _uten_ å opprette pdf. Vil gjøre forhåndsvisning til saksbehandling vesentlig raskere. 