### PR TITLE
Oppdaterer til nyaste ey-pdfgen-versjon. 1.5.0 har sikkerheitsproblem…

### DIFF
--- a/apps/ey-pdfgen/.nais/dev.yaml
+++ b/apps/ey-pdfgen/.nais/dev.yaml
@@ -19,9 +19,9 @@ spec:
       cpu: 100m
       memory: 256Mi
   liveness:
-    path: /is_alive
+    path: /internal/is_alive
   readiness:
-    path: /is_alive
+    path: /internal/is_ready
   prometheus:
     enabled: true
     path: /prometheus

--- a/apps/ey-pdfgen/.nais/prod.yaml
+++ b/apps/ey-pdfgen/.nais/prod.yaml
@@ -17,9 +17,9 @@ spec:
       cpu: 100m
       memory: 256Mi
   liveness:
-    path: /is_alive
+    path: /internal/is_alive
   readiness:
-    path: /is_alive
+    path: /internal/is_ready
   prometheus:
     enabled: true
     path: /prometheus

--- a/apps/ey-pdfgen/Dockerfile
+++ b/apps/ey-pdfgen/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/pdfgen:1.5.0
+FROM ghcr.io/navikt/pdfgen:2.0.21
 
 COPY templates /app/templates
 COPY fonts /app/fonts

--- a/apps/ey-pdfgen/run_development.sh
+++ b/apps/ey-pdfgen/run_development.sh
@@ -12,4 +12,4 @@ docker run \
         -e DISABLE_PDF_GET=false \
         -it \
         --rm \
-        ghcr.io/navikt/pdfgen:1.5.0
+        ghcr.io/navikt/pdfgen:2.0.21


### PR DESCRIPTION
…, melder naiskonsollet

Ref https://salsa.nav.cloud.nais.io/projects/1743b820-7418-4d5a-8301-a7ebd94358c6/findings og https://console.nav.cloud.nais.io/team/etterlatte/vulnerabilities

Testa lokalt med både eksisterande og ny versjon, dei ser like ut.
Barnepensjon, 1.5.0:
[bp_150.pdf](https://github.com/navikt/pensjon-etterlatte-felles/files/13647422/bp_150.pdf)

Barnepensjon, 2.0.21:
[bp_pdfgen2021.pdf](https://github.com/navikt/pensjon-etterlatte-felles/files/13647426/bp_pdfgen2021.pdf)


Gjenlevendepensjon, 1.5.0:
[gp_150.pdf](https://github.com/navikt/pensjon-etterlatte-felles/files/13647425/gp_150.pdf)

Gjenlevendepensjon, 2.0.21:
[gp_pdfgen2021.pdf](https://github.com/navikt/pensjon-etterlatte-felles/files/13647424/gp_pdfgen2021.pdf)
