### PR TITLE
Legg til ingenInntekt og inntektViaYtelserFraNAV

### DIFF
--- a/apps/ey-pdfgen/data/eypdfgen/omstillingsstoenad_v1.json
+++ b/apps/ey-pdfgen/data/eypdfgen/omstillingsstoenad_v1.json
@@ -689,6 +689,42 @@
           }
         }
       },
+      "inntektViaYtelserFraNAV": {
+        "ytelser": {
+          "spoersmaal": "Hvilke andre inntekter eller utbetalinger har du?",
+          "svar": [
+            {
+              "verdi": "DAGSPENGER",
+              "innhold": "Dagpenger"
+            },
+            {
+              "verdi": "ARBEIDSAVKLARINGSPENGER",
+              "innhold": "Arbeidsavklaringspenger"
+            }
+          ]
+        }
+      },
+      "ingenInntekt":{
+        "svar": {
+          "spoersmaal": "Har du inntekt eller noen andre utbetalinger?",
+          "svar": {
+            "verdi": "JA",
+            "innhold": "Ja"
+          }
+        },
+        "beloep": {
+          "spoersmaal": "Oppgi beløp",
+          "svar": {
+            "innhold": "320 000"
+          }
+        },
+        "beskrivelse": {
+          "spoersmaal": "Beskriv hvilken type utbetaling du har",
+          "svar": {
+            "innhold": "Får inn litt inntekt fra siden"
+          }
+        }
+      },
       "annenInntekt": {
         "annenInntektEllerUtbetaling": {
           "spoersmaal": "Hvilke andre inntekter eller utbetalinger har du?",

--- a/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/ingenInntekt.hbs
+++ b/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/ingenInntekt.hbs
@@ -1,0 +1,22 @@
+{{#if this}}
+    <h4>
+        {{#eq spraak "en"}}
+            Information about the survivors other income
+        {{else}}
+            {{#eq spraak "nn"}}
+                Opplysingar om attlevandes andre inntekter
+            {{else}}
+                Opplysninger om gjenlevendes andre inntekter
+            {{/eq}}
+        {{/eq}}
+    </h4>
+    <div>
+        {{> eypdfgen/partials_v2/common/opplysning this.svar}}
+
+        {{#eq this.svar.svar.verdi "JA"}}
+            {{> eypdfgen/partials_v2/common/opplysning this.beloep}}
+            {{> eypdfgen/partials_v2/common/opplysning this.beskrivelse}}
+        {{/eq}}
+
+    </div>
+{{/if}}

--- a/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/inntektViaYtelserFraNAV.hbs
+++ b/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/inntektViaYtelserFraNAV.hbs
@@ -1,0 +1,25 @@
+{{#if this}}
+    <h4>
+        {{#eq spraak "en"}}
+            Information about the survivors incomes or disbursements from benefits from NAV
+        {{else}}
+            {{#eq spraak "nn"}}
+                Opplysingar om attlevandes inntekter eller utbetalingar frå ytingar frå NAV
+            {{else}}
+                Opplysninger om gjenlevendes inntekter eller utbetalinger fra ytelser fra NAV
+            {{/eq}}
+        {{/eq}}
+    </h4>
+    <div>
+        <div class="row opplysning">
+            <div class="col">
+                {{this.ytelser.spoersmaal}}
+            </div>
+            <div class="col">
+                {{#each this.ytelser.svar}}
+                    • {{this.innhold}} <br />
+                {{/each}}
+            </div>
+        </div>
+    </div>
+{{/if}}

--- a/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntektenDin.hbs
+++ b/apps/ey-pdfgen/templates/eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntektenDin.hbs
@@ -17,7 +17,13 @@
 
     {{> eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/pensjon this.pensjonEllerUfoere}}
 
+    <!-- DENNE KAN FJERNES 72 TIMER ETTER DEPLOY -->
     {{> eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/annenInntekt this.annenInntekt}}
+    <!-- DENNE KAN FJERNES 72 TIMER ETTER DEPLOY -->
+
+    {{> eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/inntektViaYtelserFraNAV this.inntektViaYtelserFraNAV}}
+
+    {{> eypdfgen/partials_v2/omstillingsstoenad/gjenlevende/inntekt/ingenInntekt this.ingenInntekt}}
 
     <h4>
         {{#eq spraak "en"}}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ navFellesTokenClientCore = { module = "no.nav.security:token-client-core", versi
 tjenestespesifikasjonerTilbakekreving = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version = "1.78ffd1e"}
 
 #Etterlatte
-etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "dev.ecebe5bcf125.dev"}
-etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "dev.ecebe5bcf125.dev"}
+etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "dev.132670415540.dev"}
+etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "dev.132670415540.dev"}
 etterlatte-ktorClientAuth = { module = "pensjon-etterlatte-libs:ktor-client-auth", version = "2024.01.17-13.28.695db1c36957"}
 
 #Ktor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ navFellesTokenClientCore = { module = "no.nav.security:token-client-core", versi
 tjenestespesifikasjonerTilbakekreving = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version = "1.78ffd1e"}
 
 #Etterlatte
-etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.02.08-12.12.2ed2b049ebb9"}
-etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "2024.02.08-12.12.2ed2b049ebb9"}
+etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "dev.ecebe5bcf125.dev"}
+etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "dev.ecebe5bcf125.dev"}
 etterlatte-ktorClientAuth = { module = "pensjon-etterlatte-libs:ktor-client-auth", version = "2024.01.17-13.28.695db1c36957"}
 
 #Ktor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ navFellesTokenClientCore = { module = "no.nav.security:token-client-core", versi
 tjenestespesifikasjonerTilbakekreving = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version = "1.78ffd1e"}
 
 #Etterlatte
-etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "dev.132670415540.dev"}
-etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "dev.132670415540.dev"}
+etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.02.20-09.34.d73dc559506b"}
+etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "2024.02.20-09.34.d73dc559506b"}
 etterlatte-ktorClientAuth = { module = "pensjon-etterlatte-libs:ktor-client-auth", version = "2024.01.17-13.28.695db1c36957"}
 
 #Ktor


### PR DESCRIPTION
Lar AnnenInntekt bli for å støtte de som har startet en søknad rett før vi deployer.