### PR TITLE
Proxy: Bruker versjonar av bouncycastle- og xmlsec-biblioteka som ikkje er sårbare

### DIFF
--- a/apps/etterlatte-proxy/build.gradle.kts
+++ b/apps/etterlatte-proxy/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
         exclude("org.bouncycastle:bcpkix-jdk18on")
         exclude("org.bouncycastle:bcutil-jdk18on")
         exclude("org.apache.santuario:xmlsec")
+        exclude("org.eclipse.angus:angus-core")
+        exclude("org.eclipse.angus:angus-mail")
     }
     implementation(libs.micrometer.prometheus)
     implementation(libs.jacksonDatatypejsr310)
@@ -40,9 +42,13 @@ dependencies {
     testImplementation(libs.mockOauth2Server)
     testImplementation(libs.ktor.serverTests)
 
+    // Avhengigheter fra patching av sårbarheter i Apache CXF.
+    // Vi bør kunne ta bort alle disse og exclude-lista for neste CXF-versjon
     implementation(libs.guava)
     implementation(libs.bcprov)
     implementation(libs.bcpkix)
     implementation(libs.bcutil)
     implementation(libs.xmlsec)
+    implementation(libs.angus.core)
+    implementation(libs.angus.mail)
 }

--- a/apps/etterlatte-proxy/build.gradle.kts
+++ b/apps/etterlatte-proxy/build.gradle.kts
@@ -29,6 +29,10 @@ dependencies {
     implementation(libs.cxf.transports.http)
     implementation(libs.cxf.ws.security) {
         exclude("com.google.guava:guava")
+        exclude("org.bouncycastle:bcprov-jdk18on")
+        exclude("org.bouncycastle:bcpkix-jdk18on")
+        exclude("org.bouncycastle:bcutil-jdk18on")
+        exclude("org.apache.santuario:xmlsec")
     }
     implementation(libs.micrometer.prometheus)
     implementation(libs.jacksonDatatypejsr310)
@@ -37,4 +41,8 @@ dependencies {
     testImplementation(libs.ktor.serverTests)
 
     implementation(libs.guava)
+    implementation(libs.bcprov)
+    implementation(libs.bcpkix)
+    implementation(libs.bcutil)
+    implementation(libs.xmlsec)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ navfelles-token-version = "4.1.3"
 ktor-version = "2.3.8"
 jupiter-version = "5.10.2"
 cxf-version = "4.0.3" # Obs: Når vi oppgraderer denne, bør vi også kunne rydde bort guava og guava-workarounden
+bcprov-version = "1.74"
 
 [libraries]
 
@@ -67,4 +68,10 @@ cxf-logging = { module = "org.apache.cxf:cxf-rt-features-logging", version.ref =
 cxf-jax-ws = { module = "org.apache.cxf:cxf-rt-frontend-jaxws", version.ref = "cxf-version" }
 cxf-transports-http = { module = "org.apache.cxf:cxf-rt-transports-http", version.ref = "cxf-version" }
 cxf-ws-security = { module = "org.apache.cxf:cxf-rt-ws-security", version.ref = "cxf-version" }
+
+#Cxf-workarounds
 guava = { module = "com.google.guava:guava", version = "32.1.2-jre"} # workaround for å omgå https://github.com/google/guava/issues/6657
+bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov-version"}
+bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcprov-version"}
+bcutil = { module = "org.bouncycastle:bcutil-jdk18on", version.ref = "bcprov-version"}
+xmlsec = { module = "org.apache.santuario:xmlsec", version = "3.0.3"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktor-version = "2.3.8"
 jupiter-version = "5.10.2"
 cxf-version = "4.0.3" # Obs: Når vi oppgraderer denne, bør vi også kunne rydde bort guava og guava-workarounden
 bcprov-version = "1.74"
+angus-version = "1.1.0"
 
 [libraries]
 
@@ -75,3 +76,5 @@ bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov-ver
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcprov-version"}
 bcutil = { module = "org.bouncycastle:bcutil-jdk18on", version.ref = "bcprov-version"}
 xmlsec = { module = "org.apache.santuario:xmlsec", version = "3.0.3"}
+angus-core = { module = "org.eclipse.angus:angus-core", version.ref="angus-version"}
+angus-mail = { module = "org.eclipse.angus:angus-mail", version.ref="angus-version"}


### PR DESCRIPTION
Apache Cxf-biblioteket trekkjer med seg mykje rart, og særleg da sårbare versjonar av bibliotek.

[Dependency track](https://salsa.nav.cloud.nais.io/projects/ca531119-08dd-4cba-b77b-a0073e184ad3/findings) viser at bouncycastle-, angus- og xmlsec-biblioteka som brukast er sårbare.


Bouncycastle er oppgradert i denne PR-en frå 1.72 til 1.74, xmlsec frå 3.0.2 til 3.0.3, medan [Angus er frå 1.0 til 1.1](https://github.com/eclipse-ee4j/angus-mail/releases/tag/1.1.0) Xmlsec-oppgraderinga er kun å rette sårbarheit, dei to andre har samla opp litt meir, men det verkar også greitt.

Liker eigentleg ikkje å måtte lage denne PR-en, men det er ei avveging mellom forskjellige omsyn: sårbarheiter eller enkelt oppsett.

Nyaste versjon av CXF kom 18. september 2023. Det ser ut [som 4.0.4 er på veg](https://lists.apache.org/thread/smnbjlcgt7hmxd2msmyrym4hf3bzsskd), men det var opptil fleire andre bibliotek dei ville release først, så terskelen for at dei køyrer ut nye versjonar er (overraskande og unødig, tbh) høg.


Per no bruker vi proxy kun til tilbakekreving, og den bør vi uansett teste ordentleg før vi tar i bruk i prod, så eg synes no er eit bra tidspunkt for å ta dette løftet.