### PR TITLE
Fjerne avhengighet til libs

### DIFF
--- a/apps/etterlatte-notifikasjoner/build.gradle.kts
+++ b/apps/etterlatte-notifikasjoner/build.gradle.kts
@@ -6,9 +6,6 @@ dependencies {
     implementation(libs.ktor.jackson)
     implementation(libs.rapidAndRivers)
 
-    implementation(libs.etterlatte.common)
-    implementation(libs.etterlatte.ktorClientAuth)
-
     implementation(libs.brukernotifikasjonSchemas) {
         exclude("org.apache.commons", "commons-compress")
     }
@@ -19,5 +16,4 @@ dependencies {
     implementation(libs.kafka.clients)
 
     testImplementation(libs.mockk)
-    testImplementation(libs.etterlatte.commonTest)
 }

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
@@ -1,8 +1,8 @@
 package no.nav.etterlatte
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.InnsendtSoeknad
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -30,7 +30,7 @@ class Notifikasjon(private val sendNotifikasjon: SendNotifikasjon, rapidsConnect
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
         runBlocking {
-            val soeknad: InnsendtSoeknad = mapper.readValue(packet["@skjema_info"].toString())
+            val soeknad = mapper.readValue<Soeknad>(packet["@skjema_info"].toString())
 
             sendNotifikasjon.sendMessage(soeknad)
 

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/SendNotifikasjon.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/SendNotifikasjon.kt
@@ -1,11 +1,10 @@
 package no.nav.etterlatte
 
+import com.fasterxml.jackson.databind.JsonNode
 import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
 import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.InnsendtSoeknad
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -29,19 +28,19 @@ class SendNotifikasjon(
     private val sikkerhetsNivaa = 4
     private val eksternVarsling = false
 
-    fun sendMessage(soeknad: InnsendtSoeknad) {
-        val innsender = soeknad.innsender.foedselsnummer.svar.value
+    fun sendMessage(soeknad: Soeknad) {
+        val innsender = soeknad.innsender.foedselsnummer.value
 
-        send(opprettNokkel(innsender), opprettBeskjed(soeknad))
+        send(opprettNokkel(innsender), opprettBeskjed(soeknad.type))
     }
 
-    internal fun opprettBeskjed(soeknad: InnsendtSoeknad): BeskjedInput {
+    internal fun opprettBeskjed(type: Soeknad.Type): BeskjedInput {
         val now = LocalDateTime.now(ZoneOffset.UTC)
         val weekFromNow = now.plusDays(7)
-        val tekst = when (soeknad.type) {
-            SoeknadType.GJENLEVENDEPENSJON -> "Vi har mottatt søknaden din om gjenlevendepensjon"
-            SoeknadType.BARNEPENSJON -> "Vi har mottatt søknaden din om barnepensjon"
-            SoeknadType.OMSTILLINGSSTOENAD -> "Vi har mottatt søknaden din om omstillingsstønad"
+        val tekst = when (type) {
+            Soeknad.Type.GJENLEVENDEPENSJON -> "Vi har mottatt søknaden din om gjenlevendepensjon"
+            Soeknad.Type.BARNEPENSJON -> "Vi har mottatt søknaden din om barnepensjon"
+            Soeknad.Type.OMSTILLINGSSTOENAD -> "Vi har mottatt søknaden din om omstillingsstønad"
         }
 
         return BeskjedInputBuilder()
@@ -65,7 +64,7 @@ class SendNotifikasjon(
         producer.send(ProducerRecord(brukernotifikasjontopic, nokkel, beskjed)).get(10, TimeUnit.SECONDS)
     } catch (e: Exception) {
         logger.error(
-            "Beskjed til $brukernotifikasjontopic (Ditt NAV) for søknad med id ${nokkel.getGrupperingsId()} feilet.",
+            "Beskjed til $brukernotifikasjontopic (Ditt NAV) for søknad med id ${nokkel.grupperingsId} feilet.",
             e
         )
     }

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/Soeknad.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/Soeknad.kt
@@ -1,0 +1,25 @@
+package no.nav.etterlatte
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Soeknad(
+    val innsender: Innsender,
+    val type: Type
+) {
+    enum class Type {
+        GJENLEVENDEPENSJON,
+        BARNEPENSJON,
+        OMSTILLINGSSTOENAD
+    }
+}
+
+data class Innsender(
+    val foedselsnummer: Foedselsnummer
+)
+
+data class Foedselsnummer(
+    @JsonProperty("svar")
+    val value: String
+)

--- a/apps/etterlatte-notifikasjoner/src/test/kotlin/SendNotifikasjonTest.kt
+++ b/apps/etterlatte-notifikasjoner/src/test/kotlin/SendNotifikasjonTest.kt
@@ -2,7 +2,7 @@ import io.mockk.mockk
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.etterlatte.SendNotifikasjon
-import no.nav.etterlatte.libs.common.test.InnsendtSoeknadFixtures
+import no.nav.etterlatte.Soeknad
 import org.apache.kafka.clients.producer.Producer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -10,7 +10,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
-class SendNotifikasjonTest {
+internal class SendNotifikasjonTest {
     private val mockKafkaProducer = mockk<Producer<NokkelInput, BeskjedInput>>()
     private val sendNotifikasjon = SendNotifikasjon(
         mapOf(
@@ -20,7 +20,7 @@ class SendNotifikasjonTest {
 
     @Test
     fun `skal opprette melding for gjenlevendepensjon`() {
-        val beskjed = sendNotifikasjon.opprettBeskjed(InnsendtSoeknadFixtures.gjenlevendepensjon())
+        val beskjed = sendNotifikasjon.opprettBeskjed(Soeknad.Type.GJENLEVENDEPENSJON)
         assertEquals(false, beskjed.getEksternVarsling())
         assertEquals("Vi har mottatt søknaden din om gjenlevendepensjon", beskjed.getTekst())
         assertEquals(true, isWithin10Seconds(beskjed.getTidspunkt().toLocalDateTime()))
@@ -37,7 +37,7 @@ class SendNotifikasjonTest {
 
     @Test
     fun `skal opprette melding for barnepensjon`() {
-        val beskjed = sendNotifikasjon.opprettBeskjed(InnsendtSoeknadFixtures.barnepensjon())
+        val beskjed = sendNotifikasjon.opprettBeskjed(Soeknad.Type.BARNEPENSJON)
         assertEquals(false, beskjed.getEksternVarsling())
         assertEquals("Vi har mottatt søknaden din om barnepensjon", beskjed.getTekst())
         assertEquals(true, isWithin10Seconds(beskjed.getTidspunkt().toLocalDateTime()))
@@ -54,7 +54,7 @@ class SendNotifikasjonTest {
 
     @Test
     fun `skal opprette melding for omstillingsstoenad`() {
-        val beskjed = sendNotifikasjon.opprettBeskjed(InnsendtSoeknadFixtures.omstillingsSoeknad())
+        val beskjed = sendNotifikasjon.opprettBeskjed(Soeknad.Type.OMSTILLINGSSTOENAD)
         assertEquals(false, beskjed.getEksternVarsling())
         assertEquals("Vi har mottatt søknaden din om omstillingsstønad", beskjed.getTekst())
         assertEquals(true, isWithin10Seconds(beskjed.getTidspunkt().toLocalDateTime()))

--- a/apps/etterlatte-notifikasjoner/src/test/resources/barnepensjon.json
+++ b/apps/etterlatte-notifikasjoner/src/test/resources/barnepensjon.json
@@ -1,0 +1,209 @@
+{
+  "imageTag": "d79803f3acb657cf657ee46af1db293a665eb0d2",
+  "spraak": "nb",
+  "innsender": {
+    "fornavn": {
+      "svar": "TRADISJONSBUNDEN",
+      "spoersmaal": "Fornavn"
+    },
+    "etternavn": {
+      "svar": "KØYESENG",
+      "spoersmaal": "Etternavn"
+    },
+    "foedselsnummer": {
+      "svar": "13848599411",
+      "spoersmaal": "Fødselsnummer / d-nummer"
+    },
+    "type": "INNSENDER"
+  },
+  "harSamtykket": {
+    "svar": true,
+    "spoersmaal": "Jeg, TRADISJONSBUNDEN KØYESENG, bekrefter at jeg vil gi riktige og fullstendige opplysninger."
+  },
+  "utbetalingsInformasjon": {
+    "svar": {
+      "verdi": "NORSK",
+      "innhold": "Norsk"
+    },
+    "spoersmaal": "Ønsker du å motta utbetalingen på norsk eller utenlandsk bankkonto?",
+    "opplysning": {
+      "kontonummer": {
+        "svar": {
+          "innhold": "1231.23.13137"
+        },
+        "spoersmaal": "Oppgi norsk kontonummer for utbetaling av barnepensjon"
+      },
+      "utenlandskBankNavn": null,
+      "utenlandskBankAdresse": null,
+      "iban": null,
+      "swift": null,
+      "skattetrekk": {
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        },
+        "spoersmaal": "Ønsker du at vi legger inn et skattetrekk for barnepensjonen?",
+        "opplysning": null
+      }
+    }
+  },
+  "soeker": {
+    "fornavn": {
+      "svar": "Blaut",
+      "spoersmaal": "Fornavn"
+    },
+    "etternavn": {
+      "svar": "Sandkasse",
+      "spoersmaal": "Etternavn"
+    },
+    "foedselsnummer": {
+      "svar": "19021370870",
+      "spoersmaal": "Fødselsnummer / d-nummer"
+    },
+    "statsborgerskap": {
+      "svar": "Norge",
+      "spoersmaal": "Statsborgerskap"
+    },
+    "utenlandsAdresse": {
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      },
+      "spoersmaal": "Bor barnet i et annet land enn Norge?",
+      "opplysning": null
+    },
+    "bosattNorge": null,
+    "foreldre": [
+      {
+        "fornavn": {
+          "svar": "TRADISJONSBUNDEN",
+          "spoersmaal": "Fornavn"
+        },
+        "etternavn": {
+          "svar": "KØYESENG",
+          "spoersmaal": "Etternavn"
+        },
+        "foedselsnummer": {
+          "svar": "13848599411",
+          "spoersmaal": "Fødselsnummer / d-nummer"
+        },
+        "type": "FORELDER"
+      },
+      {
+        "fornavn": {
+          "svar": "TREG",
+          "spoersmaal": "Fornavn"
+        },
+        "etternavn": {
+          "svar": "BILDE",
+          "spoersmaal": "Etternavn"
+        },
+        "foedselsnummer": {
+          "svar": "03428317423",
+          "spoersmaal": "Fødselsnummer / d-nummer"
+        },
+        "type": "FORELDER"
+      }
+    ],
+    "ukjentForelder": null,
+    "verge": {
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      },
+      "spoersmaal": "Er det oppnevnt en verge for barnet?",
+      "opplysning": null
+    },
+    "dagligOmsorg": null,
+    "type": "BARN"
+  },
+  "foreldre": [
+    {
+      "fornavn": {
+        "svar": "TRADISJONSBUNDEN",
+        "spoersmaal": "Fornavn"
+      },
+      "etternavn": {
+        "svar": "KØYESENG",
+        "spoersmaal": "Etternavn"
+      },
+      "foedselsnummer": {
+        "svar": "13848599411",
+        "spoersmaal": "Fødselsnummer / d-nummer"
+      },
+      "adresse": {
+        "svar": "Tonnesveien 275, 8750 Tonnes",
+        "spoersmaal": "Bostedsadresse"
+      },
+      "statsborgerskap": {
+        "svar": "Norge",
+        "spoersmaal": "Statsborgerskap"
+      },
+      "kontaktinfo": {
+        "telefonnummer": {
+          "svar": {
+            "innhold": "+4799999999"
+          },
+          "spoersmaal": "Telefonnummer"
+        }
+      },
+      "type": "GJENLEVENDE_FORELDER"
+    },
+    {
+      "fornavn": {
+        "svar": "TREG",
+        "spoersmaal": "Fornavn"
+      },
+      "etternavn": {
+        "svar": "BILDE",
+        "spoersmaal": "Etternavn"
+      },
+      "foedselsnummer": {
+        "svar": "03428317423",
+        "spoersmaal": "Fødselsnummer / d-nummer"
+      },
+      "datoForDoedsfallet": {
+        "svar": {
+          "innhold": "2023-11-01"
+        },
+        "spoersmaal": "Når skjedde dødsfallet?"
+      },
+      "statsborgerskap": {
+        "svar": {
+          "innhold": "Norge"
+        },
+        "spoersmaal": "Statsborgerskap"
+      },
+      "utenlandsopphold": {
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        },
+        "spoersmaal": "Har han eller hun bodd og/eller arbeidet i et annet land enn Norge etter fylte 16 år?",
+        "opplysning": null
+      },
+      "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        },
+        "spoersmaal": "Skyldes dødsfallet yrkesskade eller yrkessykdom?"
+      },
+      "naeringsInntekt": {
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        },
+        "spoersmaal": "Var han eller hun selvstendig næringsdrivende?",
+        "opplysning": null
+      },
+      "militaertjeneste": null,
+      "type": "AVDOED"
+    }
+  ],
+  "soesken": [],
+  "versjon": "2",
+  "type": "BARNEPENSJON",
+  "mottattDato": "2023-11-30T18:05:49.337092713",
+  "template": "barnepensjon_v2"
+}

--- a/apps/etterlatte-notifikasjoner/src/test/resources/gjenlevendepensjon.json
+++ b/apps/etterlatte-notifikasjoner/src/test/resources/gjenlevendepensjon.json
@@ -1,0 +1,563 @@
+{
+  "imageTag": "d79803f3acb657cf657ee46af1db293a665eb0d2",
+  "spraak": "nb",
+  "type": "GJENLEVENDEPENSJON",
+  "harSamtykket": {
+    "spoersmaal": "Jeg, TØFF DAL, bekrefter at jeg vil gi riktige og fullstendige opplysninger.",
+    "svar": true
+  },
+  "innsender": {
+    "type": "INNSENDER",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TØFF"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "DAL"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "14838099980"
+    }
+  },
+  "utbetalingsInformasjon": {
+    "spoersmaal": "Ønsker du å motta utbetalingen på norsk eller utenlandsk bankkonto?",
+    "svar": {
+      "verdi": "NORSK",
+      "innhold": "Norsk"
+    },
+    "opplysning": {
+      "kontonummer": {
+        "spoersmaal": "Oppgi norsk kontonummer for utbetaling",
+        "svar": {
+          "innhold": "1111.60.11554"
+        }
+      }
+    }
+  },
+  "soeker": {
+    "type": "GJENLEVENDE",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TØFF"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "DAL"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "14838099980"
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": "Norge"
+    },
+    "sivilstatus": {
+      "spoersmaal": "Sivilstatus",
+      "svar": "Enke eller enkemann"
+    },
+    "adresse": {
+      "spoersmaal": "Bostedsadresse",
+      "svar": "Nøsterudveien 48, 3060 Svelvik"
+    },
+    "kontaktinfo": {
+      "telefonnummer": {
+        "spoersmaal": "Telefonnummer",
+        "svar": {
+          "innhold": "+4799999999"
+        }
+      }
+    },
+    "oppholdUtland": {
+      "spoersmaal": "Har du oppholdt deg i Norge de siste 12 månedene?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    },
+    "nySivilstatus": {
+      "spoersmaal": "Sivilstanden din i dag",
+      "svar": {
+        "verdi": "ENSLIG",
+        "innhold": "Enslig"
+      }
+    },
+    "arbeidOgUtdanning": {
+      "dinSituasjon": {
+        "spoersmaal": "Hva er situasjonen din nå?",
+        "svar": [
+          {
+            "verdi": "ARBEIDSTAKER",
+            "innhold": "Jeg er arbeidstaker"
+          },
+          {
+            "verdi": "SELVSTENDIG",
+            "innhold": "Jeg er selvstendig næringsdrivende"
+          },
+          {
+            "verdi": "UNDER_UTDANNING",
+            "innhold": "Jeg tar utdanning"
+          },
+          {
+            "verdi": "ARBEIDSSOEKER",
+            "innhold": "Jeg er arbeidssøker"
+          },
+          {
+            "verdi": "INGEN",
+            "innhold": "Annet"
+          }
+        ]
+      },
+      "arbeidsforhold": {
+        "spoersmaal": "Om arbeidsgiver",
+        "svar": [
+          {
+            "arbeidsgiver": {
+              "spoersmaal": "Hva heter arbeidsgiver?",
+              "svar": {
+                "innhold": "Ledelse AS"
+              }
+            },
+            "ansettelsesforhold": {
+              "spoersmaal": "Type ansettelse",
+              "svar": {
+                "verdi": "SESONGARBEID",
+                "innhold": "Sesongansatt"
+              }
+            },
+            "stillingsprosent": {
+              "spoersmaal": "Hvor mye jobber du?",
+              "svar": {
+                "innhold": "100"
+              }
+            },
+            "endretInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg de neste 12 månedene?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              },
+              "opplysning": {
+                "spoersmaal": "Hva er grunnen til endringene?",
+                "svar": {
+                  "innhold": "Andre grunner"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "selvstendig": {
+        "spoersmaal": "Om næringen",
+        "svar": [
+          {
+            "firmanavn": {
+              "spoersmaal": "Om næringen",
+              "svar": {
+                "innhold": "Selvstendig firma ENK"
+              }
+            },
+            "orgnr": {
+              "spoersmaal": "Organisasjonsnummer",
+              "svar": {
+                "innhold": "999999999"
+              }
+            },
+            "endretInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg de neste 12 månedene?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              },
+              "opplysning": {
+                "spoersmaal": "Hva er grunnen til endringene?",
+                "svar": {
+                  "innhold": "Selger mye varer"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "utdanning": {
+        "spoersmaal": "dinSituasjon.utdanning.naavaerendeUtdanning.tittel",
+        "svar": {
+          "navn": {
+            "spoersmaal": "Navnet på utdanningen",
+            "svar": {
+              "innhold": "Heimdal vgs"
+            }
+          },
+          "startDato": {
+            "spoersmaal": "Fra dato",
+            "svar": {
+              "innhold": "2023-09-06"
+            }
+          },
+          "sluttDato": {
+            "spoersmaal": "Til dato",
+            "svar": {
+              "innhold": "2023-12-22"
+            }
+          }
+        }
+      },
+      "annet": {
+        "spoersmaal": "Velg det som beskriver situasjonen din fra nedtrekksmenyen.",
+        "svar": {
+          "innhold": "Etablerer bedrift",
+          "verdi": "ETABLERER_BEDRIFT"
+        }
+      }
+    },
+    "fullfoertUtdanning": {
+      "spoersmaal": "Hva er din høyeste fullførte utdanning?",
+      "svar": {
+        "verdi": "FAGBREV",
+        "innhold": "Fagbrev"
+      }
+    },
+    "andreYtelser": {
+      "kravOmAnnenStonad": {
+        "spoersmaal": "Har du søkt om andre ytelser som du ikke har fått svar på?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "spoersmaal": "Hva har du søkt om?",
+          "svar": {
+            "verdi": "OPPLAERINGSPENGER",
+            "innhold": "Opplæringspenger"
+          }
+        }
+      },
+      "annenPensjon": {
+        "spoersmaal": "Får du eller har du søkt om avtalefestet pensjon (AFP) eller annen pensjon fra andre enn NAV?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "spoersmaal": "Hvilken pensjonsordning?",
+          "svar": {
+            "innhold": "Skandia"
+          }
+        }
+      },
+      "pensjonUtland": {
+        "spoersmaal": "Mottar du pensjon fra et annet land enn Norge?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "pensjonsType": {
+            "spoersmaal": "Hva slags pensjon?",
+            "svar": {
+              "innhold": "Alder"
+            }
+          },
+          "land": {
+            "spoersmaal": "Fra hvilket land?",
+            "svar": {
+              "innhold": "Norge"
+            }
+          },
+          "bruttobeloepPrAar": {
+            "spoersmaal": "Årlig beløp før skatt i landets valuta",
+            "svar": {
+              "innhold": "6900"
+            }
+          }
+        }
+      }
+    },
+    "uregistrertEllerVenterBarn": {
+      "spoersmaal": "Venter du barn eller har du barn som enda ikke er registrert i folkeregisteret?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    },
+    "forholdTilAvdoede": {
+      "relasjon": {
+        "spoersmaal": "Relasjonen din til avdøde da dødsfallet skjedde",
+        "svar": {
+          "verdi": "SEPARERT",
+          "innhold": "Separert"
+        }
+      },
+      "datoForInngaattPartnerskap": {
+        "spoersmaal": "Vi giftet oss",
+        "svar": {
+          "innhold": "2023-12-01"
+        }
+      },
+      "fellesBarn": {
+        "spoersmaal": "Har eller hadde dere felles barn?",
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        }
+      },
+      "omsorgForBarn": {
+        "spoersmaal": "Hadde du omsorg for avdødes barn på dødstidspunktet?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        }
+      }
+    }
+  },
+  "avdoed": {
+    "type": "AVDOED",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "Avdød"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "Avdødsen"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer / d-nummer",
+      "svar": "23096800177"
+    },
+    "datoForDoedsfallet": {
+      "spoersmaal": "Når skjedde dødsfallet?",
+      "svar": {
+        "innhold": "2023-12-01"
+      }
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": {
+        "innhold": "Belgia"
+      }
+    },
+    "utenlandsopphold": {
+      "spoersmaal": "Har han eller hun bodd og/eller arbeidet i et annet land enn Norge etter fylte 16 år?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": [
+        {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Argentina"
+            }
+          },
+          "fraDato": {
+            "spoersmaal": "Fra dato (valgfri)",
+            "svar": {
+              "innhold": "2023-10-04"
+            }
+          },
+          "tilDato": {
+            "spoersmaal": "Til dato (valgfri)",
+            "svar": {
+              "innhold": "2023-11-16"
+            }
+          },
+          "oppholdsType": {
+            "spoersmaal": "Bodd og/eller arbeidet?",
+            "svar": [
+              {
+                "verdi": "BODD",
+                "innhold": "Bodd"
+              }
+            ]
+          },
+          "medlemFolketrygd": {
+            "spoersmaal": "Var han eller hun medlem av folketrygden under oppholdet?",
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "Nei"
+            }
+          },
+          "pensjonsutbetaling": {
+            "spoersmaal": "Oppgi eventuell pensjon han eller hun mottok fra dette landet (valgfri)",
+            "svar": {
+              "innhold": "150 svenske kroner"
+            }
+          }
+        }
+      ]
+    },
+    "naeringsInntekt": {
+      "spoersmaal": "Var han eller hun selvstendig næringsdrivende?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "naeringsinntektPrAarFoerDoedsfall": {
+          "spoersmaal": "Oppgi næringsinntekt fra kalenderåret før dødsfallet (valgfri)",
+          "svar": {
+            "innhold": "199"
+          }
+        },
+        "naeringsinntektVedDoedsfall": {
+          "spoersmaal": "Hadde han eller hun næringsinntekt når dødsfallet skjedde?",
+          "svar": {
+            "verdi": "JA",
+            "innhold": "Ja"
+          }
+        }
+      }
+    },
+    "militaertjeneste": {
+      "spoersmaal": "Har han eller hun gjennomført militær eller sivil førstegangstjeneste for Norge som varte minst 30 dager?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "spoersmaal": "Hvilke(-t) år? (valgfri)",
+        "svar": {
+          "innhold": "1969"
+        }
+      }
+    },
+    "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+      "spoersmaal": "Skyldes dødsfallet yrkesskade eller yrkessykdom?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    }
+  },
+  "barn": [
+    {
+      "type": "BARN",
+      "fornavn": {
+        "spoersmaal": "Fornavn",
+        "svar": "Testmini"
+      },
+      "etternavn": {
+        "spoersmaal": "Etternavn",
+        "svar": "Minion"
+      },
+      "foedselsnummer": {
+        "spoersmaal": "Barnets fødselsnummer / d-nummer",
+        "svar": "05111850870"
+      },
+      "statsborgerskap": {
+        "spoersmaal": "Statsborgerskap",
+        "svar": "Andorra"
+      },
+      "utenlandsAdresse": {
+        "spoersmaal": "Bor barnet i et annet land enn Norge?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Australia"
+            }
+          },
+          "adresse": {
+            "spoersmaal": "Adresse i utlandet",
+            "svar": {
+              "innhold": "Utlandet"
+            }
+          }
+        }
+      },
+      "foreldre": [
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "TØFF"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "DAL"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "14838099980"
+          }
+        },
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Avdød"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Avdødsen"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "23096800177"
+          }
+        }
+      ],
+      "verge": {
+        "spoersmaal": "Er det oppnevnt en verge for barnet?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "type": "VERGE",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Verg"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Erge"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "25027702638"
+          }
+        }
+      }
+    }
+  ],
+  "andreStoenader": [
+    {
+      "spoersmaal": "Informasjon om stønad til skolepenger",
+      "svar": {
+        "innhold": "Jeg har utgifter til skolepenger",
+        "verdi": "SKOLEPENGER"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om tilleggsstønad til skoleutgifter",
+      "svar": {
+        "innhold": "Jeg har utgifter til utdanning",
+        "verdi": "TILLEGGSSTOENAD_UTDANNING"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om stønad til barnetilsyn",
+      "svar": {
+        "innhold": "Jeg har utgifter til barnetilsyn",
+        "verdi": "BARNETILSYN"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om tilleggsstønad til pass av barn",
+      "svar": {
+        "innhold": "Jeg har utgifter til pass av barn",
+        "verdi": "TILLEGGSSTOENAD_BARNEPASS"
+      }
+    }
+  ],
+  "mottattDato": "2023-11-30T18:05:49.337092713",
+  "template": "gjenlevendepensjon_v2"
+}

--- a/apps/etterlatte-notifikasjoner/src/test/resources/omstillingsstoenad.json
+++ b/apps/etterlatte-notifikasjoner/src/test/resources/omstillingsstoenad.json
@@ -1,0 +1,741 @@
+{
+  "imageTag": "d79803f3acb657cf657ee46af1db293a665eb0d2",
+  "spraak": "nb",
+  "type": "OMSTILLINGSSTOENAD",
+  "harSamtykket": {
+    "spoersmaal": "Jeg vil svare så godt jeg kan på spørsmålene i søknaden.",
+    "svar": true
+  },
+  "innsender": {
+    "type": "INNSENDER",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "KALD"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "FOLK"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "24876696580"
+    }
+  },
+  "utbetalingsInformasjon": {
+    "spoersmaal": "Ønsker du å motta utbetalingen på norsk eller utenlandsk bankkonto?",
+    "svar": {
+      "verdi": "NORSK",
+      "innhold": "Norsk"
+    },
+    "opplysning": {
+      "kontonummer": {
+        "spoersmaal": "Oppgi norsk kontonummer for utbetaling",
+        "svar": {
+          "innhold": "1241.24.12412"
+        }
+      }
+    }
+  },
+  "soeker": {
+    "type": "GJENLEVENDE_OMS",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "KALD"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "FOLK"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "24876696580"
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": "Norge"
+    },
+    "sivilstatus": {
+      "spoersmaal": "Sivilstatus",
+      "svar": "Gift"
+    },
+    "adresse": {
+      "spoersmaal": "Bostedsadresse",
+      "svar": "Nedre Ovrå 28, 6212 Liabygda"
+    },
+    "kontaktinfo": {
+      "telefonnummer": {
+        "spoersmaal": "Telefonnummer",
+        "svar": {
+          "innhold": "+4799999999"
+        }
+      }
+    },
+    "oppholdUtland": {
+      "spoersmaal": "Er du bosatt i Norge?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "oppholderSegIUtlandet": {
+          "spoersmaal": "Har du bodd eller oppholdt deg i utlandet de siste 12 månedene?",
+          "svar": {
+            "verdi": "NEI",
+            "innhold": "Nei"
+          }
+        }
+      }
+    },
+    "nySivilstatus": {
+      "spoersmaal": "Sivilstanden din i dag",
+      "svar": {
+        "verdi": "ENSLIG",
+        "innhold": "Enslig"
+      }
+    },
+    "arbeidOgUtdanning": {
+      "dinSituasjon": {
+        "spoersmaal": "Hva er situasjonen din nå?",
+        "svar": [
+          {
+            "verdi": "ARBEIDSTAKER",
+            "innhold": "Jeg er arbeidstaker og/eller lønnsmottaker som frilanser"
+          }
+        ]
+      },
+      "arbeidsforhold": {
+        "spoersmaal": "Om arbeidsforholdet ditt",
+        "svar": [
+          {
+            "arbeidsgiver": {
+              "spoersmaal": "Navn på arbeidssted",
+              "svar": {
+                "innhold": "NAV"
+              }
+            },
+            "arbeidsmengde": {
+              "spoersmaal": "Fyll ut stillingsprosenten din",
+              "svar": {
+                "innhold": "100% Prosent"
+              }
+            },
+            "ansettelsesforhold": {
+              "spoersmaal": "Hva slags type ansettelsesforhold har du?",
+              "svar": {
+                "verdi": "FAST",
+                "innhold": "Fast ansatt"
+              }
+            },
+            "endretArbeidssituasjon": {
+              "spoersmaal": "Forventer du endringer i arbeidsforholdet ditt fremover i tid?",
+              "svar": {
+                "verdi": "NEI",
+                "innhold": "Nei"
+              }
+            }
+          },
+          {
+            "arbeidsgiver": {
+              "spoersmaal": "Navn på arbeidssted",
+              "svar": {
+                "innhold": "EH"
+              }
+            },
+            "arbeidsmengde": {
+              "spoersmaal": "Fyll ut stillingsprosenten din",
+              "svar": {
+                "innhold": "30 Prosent"
+              }
+            },
+            "ansettelsesforhold": {
+              "spoersmaal": "Hva slags type ansettelsesforhold har du?",
+              "svar": {
+                "verdi": "FAST",
+                "innhold": "Fast ansatt"
+              }
+            },
+            "endretArbeidssituasjon": {
+              "spoersmaal": "Forventer du endringer i arbeidsforholdet ditt fremover i tid?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              },
+              "opplysning": {
+                "spoersmaal": "Gi en kort beskrivelse av endringene",
+                "svar": {
+                  "innhold": "Hmmm"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "fullfoertUtdanning": {
+      "spoersmaal": "Hva er din høyeste fullførte utdanning?",
+      "svar": [
+        {
+          "verdi": "UNIVERSITET_OVER_4_AAR",
+          "innhold": "Universitet eller høyskole mer enn 4 år"
+        },
+        {
+          "verdi": "FAGBREV",
+          "innhold": "Fagbrev"
+        },
+        {
+          "verdi": "ANNEN",
+          "innhold": "Annen utdanning"
+        }
+      ]
+    },
+    "inntektOgPensjon": {
+      "loennsinntekt": {
+        "spoersmaal": "Arbeidsinntekt",
+        "svar": {
+          "norgeEllerUtland": {
+            "spoersmaal": "Hvor har du arbeidsinntekt fra?",
+            "svar": [
+              {
+                "verdi": "NORGE",
+                "innhold": "Norge"
+              },
+              {
+                "verdi": "UTLAND",
+                "innhold": "Utland"
+              }
+            ]
+          },
+          "norge": {
+            "inntektAaretFoerDoedsfall": {
+              "spoersmaal": "Hva var brutto årsinntekt året før dødsfallet?",
+              "svar": {
+                "innhold": "500000"
+              }
+            },
+            "inntektIFjor": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            },
+            "inntektIAar": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            }
+          },
+          "utland": {
+            "inntektAaretFoerDoedsfall": {
+              "spoersmaal": "Hva var brutto årsinntekt året før dødsfallet?",
+              "svar": {
+                "innhold": "500000"
+              }
+            },
+            "inntektIFjor": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            },
+            "inntektIAar": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            }
+          },
+          "endringAvInntekt": {
+            "fremtidigEndringAvInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg fremover i tid?",
+              "svar": {
+                "verdi": "VET_IKKE",
+                "innhold": "Vet ikke"
+              }
+            }
+          }
+        }
+      },
+      "naeringsinntekt": {
+        "spoersmaal": "Næringsinntekt",
+        "svar": {
+          "norgeEllerUtland": {
+            "spoersmaal": "Hvor har du næringsinntekt fra?",
+            "svar": [
+              {
+                "verdi": "NORGE",
+                "innhold": "Norge"
+              },
+              {
+                "verdi": "UTLAND",
+                "innhold": "Utland"
+              }
+            ]
+          },
+          "norge": {
+            "inntektAaretFoerDoedsfall": {
+              "spoersmaal": "Hva var brutto årsinntekt året før dødsfallet?",
+              "svar": {
+                "innhold": "500000"
+              }
+            },
+            "inntektIFjor": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            },
+            "inntektIAar": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            }
+          },
+          "utland": {
+            "inntektAaretFoerDoedsfall": {
+              "spoersmaal": "Hva var brutto årsinntekt året før dødsfallet?",
+              "svar": {
+                "innhold": "500000"
+              }
+            },
+            "inntektIFjor": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            },
+            "inntektIAar": {
+              "tilDoedsfall": {
+                "spoersmaal": "Hva var brutto arbeidsinntekt frem til dødsfallet?",
+                "svar": {
+                  "innhold": "500000"
+                }
+              },
+              "aarsinntekt": {
+                "spoersmaal": "Hva forventer du i brutto årsinntekt til neste år?",
+                "svar": {
+                  "innhold": "140 000"
+                }
+              }
+            }
+          },
+          "endringAvInntekt": {
+            "fremtidigEndringAvInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg fremover i tid?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              }
+            },
+            "grunn": {
+              "spoersmaal": "Hva er grunnen til endringene?",
+              "svar": {
+                "verdi": "REDUSERT_STILLINGSPROSENT",
+                "innhold": "Redusert stillingsprosent"
+              }
+            }
+          }
+        }
+      },
+      "pensjonEllerUfoere": {
+        "pensjonstype": {
+          "spoersmaal": "Hvilken pensjon eller trygd har du?",
+          "svar": [
+            {
+              "verdi": "UFOEREPENSJON_FRA_NAV",
+              "innhold": "Uføretrygd fra NAV"
+            },
+            {
+              "verdi": "ALDERSPENSJON_FRA_NAV",
+              "innhold": "Alderspensjon fra NAV"
+            },
+            {
+              "verdi": "TJENESTEPENSJONSORDNING",
+              "innhold": "Pensjon fra tjenestepensjonsordning"
+            }
+          ]
+        },
+        "tjenestepensjonsordning": {
+          "type": {
+            "spoersmaal": "Hva slags pensjon mottar du?",
+            "svar": {
+              "verdi": "AVTALEFESTET_PENSJON_OFFENTLIG",
+              "innhold": "Avtalefestet pensjon i offentlig sektor"
+            }
+          },
+          "utbetaler": {
+            "spoersmaal": "Hvilken tjenestepensjonsordning utbetaler pensjonen din?",
+            "svar": {
+              "innhold": "Satans Pensjonskasse"
+            }
+          }
+        },
+        "utland": {
+          "svar": {
+            "spoersmaal": "Mottar du pensjon fra utlandet?",
+            "svar": {
+              "verdi": "JA",
+              "innhold": "Ja"
+            }
+          },
+          "type": {
+            "spoersmaal": "Hva slags pensjon?",
+            "svar": {
+              "innhold": "Ufør"
+            }
+          },
+          "land": {
+            "spoersmaal": "Hvilket land mottar du fra? ",
+            "svar": {
+              "innhold": "Polen"
+            }
+          },
+          "beloepMedValuta": {
+            "spoersmaal": "Årlig beløp i landets valuta",
+            "svar": {
+              "innhold": "4000 PLN"
+            }
+          }
+        }
+      },
+      "annenInntekt": {
+        "annenInntektEllerUtbetaling": {
+          "spoersmaal": "Hvilke andre inntekter eller utbetalinger har du?",
+          "svar": [
+            {
+              "verdi": "DAGSPENGER",
+              "innhold": "Dagpenger"
+            },
+            {
+              "verdi": "SVANGERSKAPSPENGER",
+              "innhold": "Svangerskapspenger"
+            },
+            {
+              "verdi": "KOMMUNAL_OMSORGSSTOENAD",
+              "innhold": "Kommunal omsorgsstønad"
+            }
+          ]
+        }
+      },
+      "ytelserNAV": {
+        "soektOmYtelse": {
+          "spoersmaal": "Har du søkt om ytelser fra NAV som du ikke har fått svar på?",
+          "svar": {
+            "verdi": "JA",
+            "innhold": "Ja"
+          }
+        },
+        "soektYtelse": {
+          "spoersmaal": "Hva har du søkt om?",
+          "svar": [
+            {
+              "verdi": "FORELDREPENGER",
+              "innhold": "Foreldrepenger"
+            },
+            {
+              "verdi": "OMSORGSPENGER",
+              "innhold": "Omsorgspenger"
+            },
+            {
+              "verdi": "FOSTERHJEMSGODTGJOERING",
+              "innhold": "Fosterhjemsgodtgjøring"
+            }
+          ]
+        }
+      },
+      "ytelserAndre": {
+        "soektOmYtelse": {
+          "spoersmaal": "Har du søkt om ytelser fra andre enn NAV som du ikke har fått svar på?",
+          "svar": {
+            "verdi": "NEI",
+            "innhold": "Nei"
+          }
+        }
+      }
+    },
+    "uregistrertEllerVenterBarn": {
+      "spoersmaal": "Venter du barn eller har du barn som ikke er registrert i folkeregisteret?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    },
+    "forholdTilAvdoede": {
+      "relasjon": {
+        "spoersmaal": "Relasjonen din til avdøde da dødsfallet skjedde",
+        "svar": {
+          "verdi": "GIFT",
+          "innhold": "Gift eller registrert partner"
+        }
+      },
+      "datoForInngaattPartnerskap": {
+        "spoersmaal": "Vi giftet oss",
+        "svar": {
+          "innhold": "2005-12-01"
+        }
+      },
+      "fellesBarn": {
+        "spoersmaal": "Har eller har dere hatt felles barn?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        }
+      }
+    },
+    "omsorgForBarn": {
+      "spoersmaal": "Har du minst 50 prosent omsorg for barn under 18 år på dødsfallstidspunktet?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    }
+  },
+  "avdoed": {
+    "type": "AVDOED",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "Overeksponert"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "Mobiltelefon"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer / d-nummer",
+      "svar": "16498203950"
+    },
+    "datoForDoedsfallet": {
+      "spoersmaal": "Når skjedde dødsfallet?",
+      "svar": {
+        "innhold": "2023-11-20"
+      }
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": {
+        "innhold": "Norge"
+      }
+    },
+    "utenlandsopphold": {
+      "spoersmaal": "Har han eller hun bodd og/eller arbeidet i et annet land enn Norge etter fylte 16 år?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": [
+        {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Sverige"
+            }
+          },
+          "fraDato": {
+            "spoersmaal": "Fra dato (valgfri)",
+            "svar": {
+              "innhold": "2003-07-22"
+            }
+          },
+          "tilDato": {
+            "spoersmaal": "Til dato (valgfri)",
+            "svar": {
+              "innhold": "2003-12-31"
+            }
+          },
+          "oppholdsType": {
+            "spoersmaal": "Bodd og/eller arbeidet?",
+            "svar": [
+              {
+                "verdi": "BODD",
+                "innhold": "Bodd"
+              },
+              {
+                "verdi": "ARBEIDET",
+                "innhold": "Arbeidet"
+              }
+            ]
+          },
+          "medlemFolketrygd": {
+            "spoersmaal": "Var han eller hun medlem av folketrygden under oppholdet?",
+            "svar": {
+              "verdi": "JA",
+              "innhold": "Ja"
+            }
+          },
+          "pensjonsutbetaling": {
+            "spoersmaal": "Oppgi eventuell pensjon han eller hun mottok fra dette landet (valgfri)",
+            "svar": {
+              "innhold": "140 000"
+            }
+          }
+        }
+      ]
+    },
+    "naeringsInntekt": {
+      "spoersmaal": "Var han eller hun selvstendig næringsdrivende?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    },
+    "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+      "spoersmaal": "Skyldes dødsfallet yrkesskade eller yrkessykdom?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    }
+  },
+  "barn": [
+    {
+      "type": "BARN",
+      "fornavn": {
+        "spoersmaal": "Fornavn",
+        "svar": "Innsiktsfull"
+      },
+      "etternavn": {
+        "spoersmaal": "Etternavn",
+        "svar": "Koloni"
+      },
+      "foedselsnummer": {
+        "spoersmaal": "Barnets fødselsnummer / d-nummer",
+        "svar": "24871899386"
+      },
+      "statsborgerskap": {
+        "spoersmaal": "Statsborgerskap",
+        "svar": "Norge"
+      },
+      "utenlandsAdresse": {
+        "spoersmaal": "Bor barnet i et annet land enn Norge?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Danmark"
+            }
+          },
+          "adresse": {
+            "spoersmaal": "Adresse i utlandet",
+            "svar": {
+              "innhold": "Kamelåså"
+            }
+          }
+        }
+      },
+      "foreldre": [
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "KALD"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "FOLK"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "24876696580"
+          }
+        },
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Overeksponert"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Mobiltelefon"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "16498203950"
+          }
+        }
+      ],
+      "verge": {
+        "spoersmaal": "Er det oppnevnt en verge for barnet?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "type": "VERGE",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Verg"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Vikernes"
+          }
+        }
+      }
+    }
+  ],
+  "andreStoenader": [],
+  "mottattDato": "2023-11-30T18:05:49.337092713",
+  "template": "omstillingsstoenad_v2"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,11 +17,6 @@ mockOauth2Server = { module = "no.nav.security:mock-oauth2-server", version = "2
 navFellesTokenClientCore = { module = "no.nav.security:token-client-core", version.ref = "navfelles-token-version"}
 tjenestespesifikasjonerTilbakekreving = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version = "1.78ffd1e"}
 
-#Etterlatte
-etterlatte-common = { module = "pensjon-etterlatte-libs:common", version = "2024.02.20-09.34.d73dc559506b"}
-etterlatte-commonTest = { module = "pensjon-etterlatte-libs:common-test", version = "2024.02.20-09.34.d73dc559506b"}
-etterlatte-ktorClientAuth = { module = "pensjon-etterlatte-libs:ktor-client-auth", version = "2024.01.17-13.28.695db1c36957"}
-
 #Ktor
 ktor-callLogging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor-version"}
 ktor-clientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor-version"}


### PR DESCRIPTION
Ingen vits å dra inn hele `etterlatte-libs` for å bruke 2 av feltene til søknaden. Fjerner derfor avhengigheten og mapper til et forenklet objekt. 

Denne appen burde på sikt endres og ta imot: 
- `mottaker fnr`
- `melding`

Da kan vi også bruke den til å varsle bruker om f.eks. ferdig behandlet søknad. 