### PR TITLE
EY-4298 Opprette mal for klageblankett (overgang fra brevbaker)

### DIFF
--- a/apps/ey-pdfgen/data/notat/klage_oversendelse_blankett.json
+++ b/apps/ey-pdfgen/data/notat/klage_oversendelse_blankett.json
@@ -1,0 +1,28 @@
+{
+  "tittel": "Klage oversendelsesblankett",
+  "payload": {
+    "formkrav": {
+      "vedtaketKlagenGjelder": {
+        "datoAttestert": "2023-06-14",
+        "vedtakType": "INNVILGELSE"
+      },
+      "erKlagenSignert": true,
+      "gjelderKlagenNoeKonkretIVedtaket": true,
+      "erKlagerPartISaken": true,
+      "erKlagenFramsattInnenFrist": true,
+      "erFormkraveneOppfylt": true,
+      "begrunnelse": "En større totalvurdering. \n\nMed linjeskift.\n\nMen fungerer det???"
+    },
+    "hjemmel": "Ftrl. § 18-3",
+    "sakId": 494,
+    "sakType": "BARNEPENSJON",
+    "sakGjelder": "Hemmelighetsfull Løvetann (15121263421)",
+    "internKommentar": "Intern kommentar til KA. \n\nSkal også støtte linjeskift. \n1.\n2.\n3.",
+    "ovesendelseTekst": "En veldig viktig innstilling. Burde også støtte linjeskift. \n\nHer er et linjeskift. Men vises det mon tro? ",
+    "klager": "15121263421",
+    "klageDato": "2024-08-13",
+    "innhold": [],
+    "sakTypeFormatert": "Barnepensjon",
+    "vedtakTypeFormatert": "Innvilgelse"
+  }
+}

--- a/apps/ey-pdfgen/templates/notat/klage_oversendelse_blankett.hbs
+++ b/apps/ey-pdfgen/templates/notat/klage_oversendelse_blankett.hbs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8"/>
+    {{> eypdfgen/partials_v2/style}}
+    <title>{{ tittel }}</title>
+</head>
+<body>
+
+<div id="header">
+    <img class="navlogo" src="{{ image "Navlogo.png" }}"/>
+
+    <h1 class="title">
+        {{ tittel }}
+    </h1>
+</div>
+
+<div class="container">
+    {{#with this.payload}}
+        {{> notat/klageblankett/informasjon this}}
+
+        {{> notat/klageblankett/formkrav this}}
+
+        {{> notat/klageblankett/vurdering this}}
+    {{/with}}
+</div>
+
+</body>
+</html>

--- a/apps/ey-pdfgen/templates/notat/klageblankett/erKravetOppfylt.hbs
+++ b/apps/ey-pdfgen/templates/notat/klageblankett/erKravetOppfylt.hbs
@@ -1,0 +1,5 @@
+{{#if this}}
+    Oppfylt
+{{else}}
+    Ikke oppfylt
+{{/if}}

--- a/apps/ey-pdfgen/templates/notat/klageblankett/formkrav.hbs
+++ b/apps/ey-pdfgen/templates/notat/klageblankett/formkrav.hbs
@@ -1,0 +1,49 @@
+<h3>Formkrav og klagefrist</h3>
+
+{{#if formkrav.vedtaketKlagenGjelder}}
+    <div class="row opplysning">
+        <div class="col">Dato vedtak attestert</div>
+        <div class="col">{{iso_to_nor_date formkrav.vedtaketKlagenGjelder.datoAttestert}}</div>
+    </div>
+    <div class="row opplysning">
+        <div class="col">Type vedtak</div>
+        <div class="col">{{vedtakTypeFormatert}}</div>
+    </div>
+{{else}}
+    <div class="row opplysning">
+        <div class="col">Vedtak som klages på</div>
+        <div class="col">Det klages ikke på et konkret vedtak</div>
+    </div>
+{{/if}}
+
+<div class="row opplysning">
+    <div class="col">Er klagen signert?</div>
+    <div class="col">
+        {{> notat/klageblankett/erKravetOppfylt formkrav.erKlagenSignert}}
+    </div>
+</div>
+<div class="row opplysning">
+    <div class="col">Er klager part i saken?</div>
+    <div class="col">
+        {{> notat/klageblankett/erKravetOppfylt formkrav.erKlagerPartISaken}}
+    </div>
+</div>
+<div class="row opplysning">
+    <div class="col">Er klagen framsatt innen frist?</div>
+    <div class="col">
+        {{> notat/klageblankett/erKravetOppfylt formkrav.erKlagenFramsattInnenFrist}}
+    </div>
+</div>
+<div class="row opplysning">
+    <div class="col">Klages det på konkrete elementer i vedtaket?</div>
+    <div class="col">
+        {{> notat/klageblankett/erKravetOppfylt formkrav.gjelderKlagenNoeKonkretIVedtaket}}
+    </div>
+</div>
+
+{{#if formkrav.begrunnelse}}
+    <div class="row opplysning">
+        <div class="col">Begrunnelse</div>
+        <div class="col">{{breaklines formkrav.begrunnelse}}</div>
+    </div>
+{{/if}}

--- a/apps/ey-pdfgen/templates/notat/klageblankett/informasjon.hbs
+++ b/apps/ey-pdfgen/templates/notat/klageblankett/informasjon.hbs
@@ -1,0 +1,26 @@
+<h3>Informasjon om saken</h3>
+
+<div class="row opplysning">
+    <div class="col">Saksnummer</div>
+    <div class="col">{{sakId}}</div>
+</div>
+
+<div class="row opplysning">
+    <div class="col">Saktype</div>
+    <div class="col">{{sakTypeFormatert}}</div>
+</div>
+
+<div class="row opplysning">
+    <div class="col">Saken gjelder</div>
+    <div class="col">{{sakGjelder}}</div>
+</div>
+
+<div class="row opplysning">
+    <div class="col">Klager</div>
+    <div class="col">{{klager}}</div>
+</div>
+
+<div class="row opplysning">
+    <div class="col">Klagedato</div>
+    <div class="col">{{iso_to_nor_date klageDato}}</div>
+</div>

--- a/apps/ey-pdfgen/templates/notat/klageblankett/vurdering.hbs
+++ b/apps/ey-pdfgen/templates/notat/klageblankett/vurdering.hbs
@@ -1,0 +1,21 @@
+<h3>Vurdering</h3>
+
+<div class="row opplysning">
+    <div class="col">Utfall</div>
+    <div class="col">Oppretthold vedtak</div>
+</div>
+<div class="row opplysning">
+    <div class="col">Hjemmel</div>
+    <div class="col">{{hjemmel}}</div>
+</div>
+<div class="row opplysning">
+    <div class="col">Innstilling til NAV Klageinstans</div>
+    <div class="col">{{breaklines ovesendelseTekst}}</div>
+</div>
+
+{{#if internKommentar}}
+    <div class="row opplysning">
+        <div class="col">Intern kommentar</div>
+        <div class="col">{{breaklines internKommentar}}</div>
+    </div>
+{{/if}}


### PR DESCRIPTION
Flytte notat på klage (klageblankett) over til ny notatstruktur. Bruker PDFGEN siden Brevbaker-gjengen ikke har noen planer om å støtte tomme strukturerte maler uten signatur og brevheader. 

Gammel til venstre, ny til høyre: 
<img width="2317" alt="Screenshot 2024-08-16 at 10 56 05" src="https://github.com/user-attachments/assets/7e1f9eda-5e0f-4fc8-9fde-60a2aba4aaba">
