### PR TITLE
Bedre varsel id for soeknad kvittering

### DIFF
--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
@@ -22,7 +22,7 @@ class Notifikasjon(
     init {
         River(rapidsConnection)
             .apply {
-                validate { it.demandValue("@event_name", "soeknad_innsendt") }
+                precondition { it.requireValue("@event_name", "soeknad_innsendt") }
                 validate { it.requireKey("@dokarkivRetur") }
                 validate { it.requireKey("@fnr_soeker") }
                 validate { it.requireKey("@skjema_info") }

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/Notifikasjon.kt
@@ -38,7 +38,7 @@ class Notifikasjon(
     ) {
         runBlocking {
             val soeknad = mapper.readValue<Soeknad>(packet["@skjema_info"].toString())
-            val soeknadId = packet["@lagret_soeknad_id"].asText()
+            val soeknadId = SoeknadId(packet["@lagret_soeknad_id"].asText())
 
             logger.info("Sender notifikasjon for søknad $soeknadId")
             sendNotifikasjon.sendMessage(soeknadId, soeknad)
@@ -48,7 +48,7 @@ class Notifikasjon(
                 .newMessage(
                     mapOf(
                         "@event_name" to "notifikasjon_sendt",
-                        "@lagret_soeknad_id" to soeknadId,
+                        "@lagret_soeknad_id" to soeknadId.toString(),
                         "@journalpostId" to journalpostId,
                         "@notifikasjon" to "Notifikasjon sendt"
                     )

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/SendNotifikasjon.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/SendNotifikasjon.kt
@@ -12,7 +12,6 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.ZonedDateTime
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class SendNotifikasjon(
@@ -22,24 +21,22 @@ class SendNotifikasjon(
     private val logger: Logger = LoggerFactory.getLogger(SendNotifikasjon::class.java)
     private val brukernotifikasjontopic = env["BRUKERNOTIFIKASJON_BESKJED_TOPIC"]!!
 
-    fun sendMessage(soeknadId: String, soeknad: Soeknad) {
+    fun sendMessage(soeknadId: SoeknadId, soeknad: Soeknad) {
         val innsender = soeknad.innsender.foedselsnummer
 
         sendVarselSMS(innsender, soeknad.type, soeknadId)
     }
 
-    internal fun sendVarselSMS(foedselsnummer: Foedselsnummer, soeknadType: Soeknad.Type, soeknadId: String) {
+    internal fun sendVarselSMS(foedselsnummer: Foedselsnummer, soeknadType: Soeknad.Type, soeknadId: SoeknadId) {
         val varslingTekst = when (soeknadType) {
             Soeknad.Type.BARNEPENSJON -> "Vi har mottatt søknaden din om barnepensjon"
             Soeknad.Type.OMSTILLINGSSTOENAD -> "Vi har mottatt søknaden din om omstillingsstønad"
         }
 
-        //TMS krever at varselId er en UUID, og vi trenger at det blir den samme UUID-en for samme søknad-ID
-        val soeknadIdSomUuid = soeknadIdSomUuid(soeknadId)
 
         val varsel =  VarselActionBuilder.opprett {
             type = Varseltype.Beskjed
-            varselId = soeknadIdSomUuid.toString()
+            varselId = soeknadId.varselIdForEtterlatte
             sensitivitet = Sensitivitet.High
             ident = foedselsnummer.value
             tekst = Tekst(
@@ -59,22 +56,13 @@ class SendNotifikasjon(
             )
         }
         try {
-            producer.send(ProducerRecord(brukernotifikasjontopic, soeknadIdSomUuid.toString(), varsel)).get(10, TimeUnit.SECONDS)
+            producer.send(ProducerRecord(brukernotifikasjontopic, soeknadId.varselIdForEtterlatte, varsel)).get(10, TimeUnit.SECONDS)
         } catch (e: Exception) {
             logger.error(
-                "Beskjed til $brukernotifikasjontopic (Min side) for søknad med id $soeknadId og varselId $soeknadIdSomUuid feilet.",
+                "Beskjed til $brukernotifikasjontopic (Min side) for søknad med id $soeknadId og varselId ${soeknadId.varselIdForEtterlatte} feilet.",
                 e
             )
         }
     }
 
-    private fun soeknadIdSomUuid(soeknadId: String): UUID {
-        try {
-            val soeknadIdLong = soeknadId.toLong()
-            return UUID(0L, soeknadIdLong)
-        }
-        catch (e: RuntimeException) {
-            throw RuntimeException("Søknad-ID $soeknadId kan ikke representeres som en UUID", e)
-        }
-    }
 }

--- a/apps/etterlatte-notifikasjoner/src/main/kotlin/SoeknadId.kt
+++ b/apps/etterlatte-notifikasjoner/src/main/kotlin/SoeknadId.kt
@@ -1,0 +1,26 @@
+package no.nav.etterlatte
+
+import java.util.UUID
+
+data class SoeknadId(val soeknadId: String) {
+
+    //TMS krever at varselId er en UUID, og vi trenger at det blir den samme UUID-en for samme søknad-ID
+    val varselIdForEtterlatte: String
+        get() = soeknadIdSomUuid().toString()
+
+private fun soeknadIdSomUuid(): UUID {
+    try {
+        // Legger til et magisk tall for å skille oss fra andre varsel-produsenter
+        val mostSigBits = 0x0DF6D91A_00000000
+        val leastSigBits = soeknadId.toLong()
+        return UUID(mostSigBits, leastSigBits)
+    }
+    catch (e: RuntimeException) {
+        throw RuntimeException("Søknad-ID $soeknadId kan ikke representeres som en UUID", e)
+    }
+}
+
+    override fun toString(): String {
+        return soeknadId
+    }
+}


### PR DESCRIPTION
For å være sikker på at vi ikke kolliderer med andre teams på "varselId" så brukes både et selvvalgt tall og søknad-ID i generering av UUID. Etter tips fra TMS (Christopher Santana).

Erstatter også deprekert måte å filtrere på @event_name i Riveren
